### PR TITLE
replicate secrets based on a regex

### DIFF
--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/types"
 	"os"
+	"regexp"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -142,7 +143,8 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 
 func contains(s []string, e string) bool {
 	for _, a := range s {
-		if a == e {
+		matched, _ := regexp.Match(a, []byte(e))
+		if a == e || matched {
 			return true
 		}
 	}

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"os"
+	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -125,7 +126,8 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 
 func contains(s []string, e string) bool {
 	for _, a := range s {
-		if a == e {
+		matched, _ := regexp.Match(a, []byte(e))
+		if a == e || matched {
 			return true
 		}
 	}


### PR DESCRIPTION
Hello,

here is a small PR that fits on of my needs: the possibility to replicate secrets based on a regex.

I've not been able to run the unit test locally:
```
[0] % make test
go generate ./pkg/... ./cmd/...
go fmt ./pkg/... ./cmd/...
go vet ./pkg/... ./cmd/...
go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
CRD manifests generated under '/home/nicolas/geek/golang/src/github.com/kiwigrid/secret-replicator/config/crds' 
RBAC manifests generated under '/home/nicolas/geek/golang/src/github.com/kiwigrid/secret-replicator/config/rbac' 
go test ./pkg/... ./cmd/... -coverprofile cover.out
?   	github.com/kiwigrid/secret-replicator/pkg/apis	[no test files]
?   	github.com/kiwigrid/secret-replicator/pkg/controller	[no test files]
2019/11/12 15:07:39 failed to start the controlplane. retried 5 times
FAIL	github.com/kiwigrid/secret-replicator/pkg/controller/namespace	0.010s
2019/11/12 15:07:39 failed to start the controlplane. retried 5 times
FAIL	github.com/kiwigrid/secret-replicator/pkg/controller/secret	0.010s
?   	github.com/kiwigrid/secret-replicator/pkg/service	[no test files]
?   	github.com/kiwigrid/secret-replicator/pkg/webhook	[no test files]
?   	github.com/kiwigrid/secret-replicator/cmd/manager	[no test files]
FAIL
make: *** [Makefile:9: test] Error 1
```

But I've been able to build my custom image and the regex part seems to to be OK.

I hope it'll help.
Nicolas