### PR TITLE
Run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/kiwi
 # Copy the controller-manager into a thin image
 FROM alpine:latest
 
-RUN mkdir /app && chown nobody /app
+RUN mkdir /app && \
+    chown nobody /app
+
 WORKDIR /app
 
 COPY --from=builder /go/src/github.com/kiwigrid/secret-replicator/manager .

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/kiwi
 
 # Copy the controller-manager into a thin image
 FROM alpine:latest
-WORKDIR /root/
+
+RUN mkdir /app && chown nobody /app
+WORKDIR /app
+
 COPY --from=builder /go/src/github.com/kiwigrid/secret-replicator/manager .
 
 # Run as nobody and make PSPs happy

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/kiwi
 FROM alpine:latest
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/kiwigrid/secret-replicator/manager .
+
+# Run as nobody and make PSPs happy
+USER 65534
+
 ENTRYPOINT ["./manager"]


### PR DESCRIPTION
Hey Kiwis :)

This PR changes the Dockerfile to run as the "nobody" user, rather than root. This is to satisfy constraints placed on Kubernetes by PodSecurityPolicies, and makes the container run nicely on a locked-down cluster!

Cheers :)
D
